### PR TITLE
Add AIOHTTP as alternative server framework

### DIFF
--- a/dec-workshop-agenda.md
+++ b/dec-workshop-agenda.md
@@ -106,7 +106,7 @@ consider coding and demo opportunities on any day, if time allows..
   - How closely can we follow (and even borrow code from) Jupyter Hub?
   - What runs where? Privileged, or as the user?
   - Server-side Python framework(s)
-    - Flask (+gevent?) or Tornado?
+    - [Flask](http://flask.pocoo.org/) (+gevent?) or [Tornado](https://www.tornadoweb.org/en/stable/) or [AIOHTTP](https://aiohttp.readthedocs.io/en/stable/)?
   - Inter-component communication - network protocols and API(s)
     - WebSocket and GraphQL seem advantageous (compared with HTTPS and a REST
       API) but do they need to go all the way from the GUI to the suite


### PR DESCRIPTION
AIOHTTP is also a good candidate to consider for web server. Its demos have examples on WebSocket and GraphQL usages.