### PR TITLE
Add code style and contributing to agenda

### DIFF
--- a/dec-workshop-agenda.md
+++ b/dec-workshop-agenda.md
@@ -94,6 +94,7 @@ consider coding and demo opportunities on any day, if time allows..
   - (Cylc Development and working practices)
   - (as we have a bunch of new team members!)
   - git, GitHub, GitHub Flow, testing, Travis CI, Codacy, Riot.im or Slack?, etc.
+  - Define Python code style guidelines (add to CONTRIBUTING.md)?
   - Development roadmap: what's been discussed and decided so far?
   - Then: begin Tuesday's Architecture discussion early, if possible
 


### PR DESCRIPTION
We have some code with old style docstrings, some formatted per Google Style docstrings, and others as reStructuredText. I think it would be easier to maintain the code with a single style. Moving to Python 3 will make us go through a lot of code, so we can use this chance to review the docs too.

We might also want to add it to CONTRIBUTING.md to contributors know how to format their code.